### PR TITLE
edit: Changing naming to AI project snaps(plural) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# AI Model Snap Documentation
+# AI Model Snaps Documentation
 
-*A repository for a private Read the Docs instance for the AI model snap documentation*
+*A repository for a private Read the Docs instance for the AI model snaps documentation*
 
 ## Description
 
-The AI model snap packages known AI models as snap packages. 
+AI model snaps packages known AI models as snap packages. 
 This project is still under development at Canonical. 
 
 Specific partners have been granted access to this project under NDA.
@@ -16,7 +16,7 @@ This section outlines the structure of this repository, and some key files.
 
 ### `docs/`
 
-This directory contains the documentation for the snap.
+This directory contains the documentation for the snaps.
 
 To view it in your browser, navigate to this directory and type `make run`.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ import yaml
 #
 # TODO: Update with the official name of your project or product
 
-project = "AI Model snap"
+project = "AI model snaps"
 author = "Canonical Ltd."
 
 

--- a/docs/explanations/index.rst
+++ b/docs/explanations/index.rst
@@ -1,7 +1,7 @@
 Explanations
 ============
 
-These documents explain different concepts that are applied in the creation and use of the AI model snap.
+These documents explain different concepts that are applied in the creation and use of AI model snaps.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/how-to/index.rst
+++ b/docs/how-to/index.rst
@@ -2,7 +2,7 @@ How-to guides
 =============
 
 These guides will walk you through the processes of configuring,
-deploying, and modifying the AI model snap.
+deploying, and modifying AI model snaps.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,7 +1,7 @@
-AI Model Snap
+AI Model Snaps
 ==========================
 
-The AI model snap allows you to package famous AI models as a snap that can be deployed on all compatible hardware. 
+AI model snaps allow you to package famous AI models as snaps that can be deployed on all compatible hardware. 
 
 It checks the hardware available on the host machine and recommends the stack that is optimised for the available hardware.
 
@@ -23,7 +23,7 @@ In this documentation
       :link: /tutorial/index
       :link-type: doc
 
-      **Get started** - a hands-on introduction to the AI model snap for new users.
+      **Get started** - a hands-on introduction to AI model snaps for new users.
 
    .. grid-item-card:: How-to guides
       :link: /how-to/index
@@ -47,5 +47,5 @@ In this documentation
    
 Project and community
 ---------------------
-The AI model snap is a Canonical product undergoing internal development. 
+AI model snaps is a Canonical product undergoing internal development. 
 Access to this documentation must be covered under Canonical's NDA.

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,7 +1,7 @@
 Reference
 =========
 
-These documents provide specifications for different set ups when using or modifying the AI model snap.
+These documents provide specifications for different set ups when using or modifying AI model snaps.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/tutorial/index.rst
+++ b/docs/tutorial/index.rst
@@ -2,7 +2,7 @@ Tutorials
 =========
 
 
-Tutorials for using the AI Model snap for developers and end users.
+Tutorials for creating and using AI model snaps for developers and end users.
 
 
 .. toctree::


### PR DESCRIPTION
Changing project name from "AI model snap documentation" to "AI model snaps documentation"
