### PR TITLE
Fix heading in engine manifest reference

### DIFF
--- a/docs/reference/engine-manifest.md
+++ b/docs/reference/engine-manifest.md
@@ -42,7 +42,7 @@ suffixes.
 ## `components`
 List of snap components required by the engine
 
-# `configurations`
+## `configurations`
 Default engine configurations
 
 (device-specific-fields)=


### PR DESCRIPTION
Fixing the false level 1 heading which shows up in the sidebar ToC. 