### PR TITLE
fix: Remove heading reference to ubuntu.com/ai

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -107,7 +107,7 @@ html_context = {
     # TODO: If there's no such website,
     #       remove the {{ product_page }} link from the page header template
     #       (usually .sphinx/_templates/header.html; also, see README.rst).
-    "product_page": "ubuntu.com/ai",
+    # "product_page": "ubuntu.com/ai", ## leaving commented out due to: https://github.com/canonical/inference-snaps/issues/57
     # Product tag image; the orange part of your logo, shown in the page header
     #
     # TODO: To add a tag image, uncomment and update as needed.


### PR DESCRIPTION
- Comment out the `product_page` due to pointing to wrong location.
- Closes: https://github.com/canonical/inference-snaps/issues/57