### PR TITLE
Revise bug report template for environment details

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -45,7 +45,7 @@ body:
       required: true
 
   - type: textarea
-    id: environment
+    id: machine
     attributes:
       label: Machine information
       description: |

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,15 +22,19 @@ body:
       required: true
 
   - type: textarea
+    id: snap-version
+    attributes:
+      label: Snap version
+      description: Provide the output of the following command: `snap list <inference-snap>`
+      render: shell
+  
+  - type: textarea
     id: environment
     attributes:
       label: Environment
       description: |
         Provide the output of the following commands:
         ```bash
-        echo -e "\nSnap information:"
-        snap list <inference-snap>`
-
         echo -e "\nSnap connections:"
         snap connections <inference-snap>
 

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -25,7 +25,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: 
+      description: |
         Provide the output of the following commands:
         ```bash
         echo -e "\nSnap information:"

--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -22,18 +22,32 @@ body:
       required: true
 
   - type: textarea
-    id: snap-version
+    id: environment
     attributes:
-      label: Snap version
-      description: Provide the output of the following command `snap list <inference-snap>`
+      label: Environment
+      description: 
+        Provide the output of the following commands:
+        ```bash
+        echo -e "\nSnap information:"
+        snap list <inference-snap>`
+
+        echo -e "\nSnap connections:"
+        snap connections <inference-snap>
+
+        echo -e "\nOS version:"
+        lsb_release -a
+
+        echo -e "\nKernel and architecture:"
+        uname -rvm
+        ```
       render: shell
-    # validations:
-    #   required: true
+    validations:
+      required: true
 
   - type: textarea
     id: environment
     attributes:
-      label: System information
+      label: Machine information
       description: |
         Provide information about your hardware.
 


### PR DESCRIPTION
Updated bug report template to include detailed environment information and changed labels for clarity.

Problem: The placeholder isn't easy to fill.