### PR TITLE
Install libcudart12 and libcublas12 instead of the whole cuda-toolkit

### DIFF
--- a/docs/how-to/install-drivers.md
+++ b/docs/how-to/install-drivers.md
@@ -35,10 +35,11 @@ sudo snap install intel-npu-driver
 You need a working CUDA setup on the host machine to use an NVIDIA GPU.
 
 The version of the driver and utilities might be different depending on your setup.
+
 On Ubuntu Server 24.04, the following commands install the appropriate packages:
 
 ```
 sudo apt update
-sudo apt install nvidia-driver-550 nvidia-utils-550 nvidia-cuda-toolkit
+sudo apt install nvidia-driver-550 nvidia-utils-550 libcudart12 libcublas12
 sudo reboot
 ```


### PR DESCRIPTION
Updated installation commands for CUDA on Ubuntu Server 24.04 to include libcudart12 and libcublas12 instead of nvidia-cuda-toolkit.