### PR TITLE
Fix and clean up external links

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -222,15 +222,7 @@ redirects = {}
 linkcheck_ignore = [
     "http://127.0.0.1:*",
     "http://localhost:*",
-    "https://github.com/canonical/ACME/*",
-    "https://github.com/canonical/deepseek-r1-snap",
-    "https://github.com/canonical/qwen-vl-snap",
-    "https://github.com/canonical/mistral-7b-instruct-snap",
-    "https://github.com/canonical/inference-snaps-dev",
-    "https://github.com/canonical/inference-snaps-cli",
-    "https://snapcraft.io/deepseek-r1",
-    "https://snapcraft.io/qwen-vl",
-    ]
+]
 
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -32,7 +32,7 @@ You can help improve this documentation by:
 - Reporting documentation issues by opening an issue on GitHub.
 
 ### License and copyright
-Unless explicitly stated in the license headers of source files, all contributions to the Inference Snaps documentation are licensed under the [Creative Commons Attribution-Share Alike (CC-BY-SA) 3.0 Unported License](http://creativecommons.org/licenses/by-sa/3.0/). 
+Unless explicitly stated in the license headers of source files, all contributions to the Inference Snaps documentation are licensed under the [Creative Commons Attribution-Share Alike (CC-BY-SA) 3.0 Unported License](https://creativecommons.org/licenses/by-sa/3.0/). 
 You can also get a copy of this license by sending a letter to Creative Commons, 171 Second Street, Suite 300, San Francisco, California, 94105, USA.
 
 All contributors must sign the [Canonical contributor license agreement](https://canonical.com/legal/contributors), which grants Canonical permission to use the contributions. 
@@ -203,8 +203,8 @@ You can also [follow Canonical’s documentation team on Fosstodon](https://foss
 [Sphinx]: https://www.sphinx-doc.org/
 [reStructuredText]: https://www.sphinx-doc.org/en/master/usage/restructuredtext/index.html
 [MyST Markdown]: https://myst-parser.readthedocs.io/en/latest/
-[starter pack guide]: https://canonical-starter-pack.readthedocs-hosted.com/latest/
-[MyST syntax guide]: https://canonical-starter-pack.readthedocs-hosted.com/latest/reference/myst-syntax-reference/
+[starter pack guide]: https://canonical-starter-pack.readthedocs-hosted.com/stable/
+[MyST syntax guide]: https://canonical-starter-pack.readthedocs-hosted.com/stable/reference/myst-syntax-reference/
 [Diátaxis]: https://diataxis.fr/
 [woke]: https://github.com/get-woke/woke
 [related issues, pull requests, and repositories]: https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/autolinked-references-and-urls

--- a/docs/reference/engine-manifest.md
+++ b/docs/reference/engine-manifest.md
@@ -130,9 +130,5 @@ When bus is set to PCI, this object inherits all {ref}`PCI peripheral <pci-perip
     key: value
 ```
 
-[^1]:  The comparison operators used for Compute Capability are based on
-[PEP](https://peps.python.org/pep-0440/#version-specifiers)
-and [Snapcraft’s Python plugin](https://snapcraft.io/docs/python-plugin).
-When compared to [npm’s semantic versioning](https://docs.npmjs.com/about-semantic-versioning)
-and [Debian package’s Depend syntax](https://www.debian.org/doc/debian-policy/ch-relationships.html),
-all operators except the equal operator match.
+[^1]: The comparison operators used for Compute Capability are based on [PEP](https://peps.python.org/pep-0440/#version-specifiers).
+When compared to [npm’s semantic versioning](https://docs.npmjs.com/about-semantic-versioning) and [Debian package’s Depend syntax](https://www.debian.org/doc/debian-policy/ch-relationships.html), all operators except the equal operator match.


### PR DESCRIPTION
Replace the broken link: `https://canonical-starter-pack.readthedocs-hosted.com/latest/`

Remove public URLs from the ignore list.

Drop extra reference to snapcraft python plugin.