### PR TITLE
Make system information optional in bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -27,8 +27,6 @@ body:
       label: Snap version
       description: Provide the output of the following command `snap list <inference-snap>`
       render: shell
-    # validations:
-    #   required: true
 
   - type: textarea
     id: environment
@@ -46,6 +44,3 @@ body:
         ```
 
         </details>
-    # validations:
-    #   required: true
-


### PR DESCRIPTION
Updated bug report template to clarify hardware information requirement.