### PR TITLE
Add how to for WSL

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -61,6 +61,7 @@ OpenAI
 OpenVINO
 optimized
 otf
+passthrough
 PCI
 plantuml
 PNG

--- a/docs/how-to/index.md
+++ b/docs/how-to/index.md
@@ -15,6 +15,7 @@ manage-snap-services
 use-openai-api
 switch-between-engines
 configure-snap
+run-in-wsl
 ```
 
 Use the snap with web clients:

--- a/docs/how-to/run-in-wsl.md
+++ b/docs/how-to/run-in-wsl.md
@@ -39,6 +39,15 @@ clinfo
 Install a supported inference snap.
 
 From the list of engines, find the engine with a description that matches your GPU:
+```shell
+<inference-snap> list-engines
+```
+
+Switch to that engine and restart the snap:
+```shell
+sudo <inference-snap> use-engine <engine-name>
+sudo snap restart <inference-snap>
+```
 
 You can verify that the engine is running by looking at the snap logs:
 ```shell

--- a/docs/how-to/run-in-wsl.md
+++ b/docs/how-to/run-in-wsl.md
@@ -1,3 +1,4 @@
+(run-in-wsl)=
 # Run an inference snap in WSL
 
 Inference snaps can be installed in WSL just like on a native Ubuntu installation.

--- a/docs/how-to/run-in-wsl.md
+++ b/docs/how-to/run-in-wsl.md
@@ -1,0 +1,50 @@
+# Run an inference snap in WSL
+
+Inference snaps can be installed in WSL just like on a native Ubuntu installation.
+The hardware detection will not detect GPUs or any other accelerators.
+A CPU engine will therefore be automatically selected.
+
+If your Windows machine has a GPU that is supported by {spellexception}`WSL's` GPU passthrough mechanism, some inference snaps can also use it.
+Refer to {ref}`available snaps <available-snaps>` to see which inference snaps are supported on WSL.
+
+## Prerequisites
+
+The GPU drivers in Windows need to be updated to a recent version that supports exposing the GPU to WSL.
+Refer to your GPU vendor's documentation for instructions on how to do this.
+
+## Verify GPU availability in WSL
+
+For NVIDIA GPUs, you can verify access using the `nvidia-smi` tool in WSL.
+
+For Intel GPUs you can use the `clinfo` tool to check if the GPU is detected.
+This tool is not available by default in WSL, but you can install it along with the Intel {spellexception}`OpenCL` drivers:
+```shell
+sudo apt update
+sudo apt install clinfo intel-opencl-icd
+clinfo
+```
+
+## Run inference snap
+
+After installing the relevant inference snap, verify which engine was automatically selected:
+```shell
+<inference-snap> status
+```
+
+You should see a CPU engine.
+
+Use `<inference-snap> list-engines` to find the engine with a description that matches your GPU.
+Switch to that engine and restart the snap.
+
+```shell
+<inference-snap> list-engines
+sudo <inference-snap> use-engine <engine-name>
+sudo snap restart <inference-snap>
+```
+
+You can verify that the engine is running by looking at the snap logs:
+```shell
+sudo snap logs <inference-snap> -f
+```
+
+If the snap starts successfully, the GPU is detected and the inference snap is ready to use.

--- a/docs/how-to/run-in-wsl.md
+++ b/docs/how-to/run-in-wsl.md
@@ -13,6 +13,15 @@ Refer to {ref}`available snaps <available-snaps>` to see which inference snaps a
 The GPU drivers in Windows need to be updated to a recent version that supports exposing the GPU to WSL.
 Refer to your GPU vendor's documentation for instructions on how to do this.
 
+The rest of this how-to assumes you have followed Microsoft's guide to [install WSL](https://learn.microsoft.com/en-us/windows/wsl/install) and create the Ubuntu Linux distribution.
+
+Fully updated and perform a restart of the Ubuntu distribution before continuing:
+```shell
+sudo apt update
+sudo apt upgrade
+sudo reboot
+```
+
 ## Verify GPU availability in WSL
 
 For NVIDIA GPUs, you can verify access using the `nvidia-smi` tool in WSL.

--- a/docs/how-to/run-in-wsl.md
+++ b/docs/how-to/run-in-wsl.md
@@ -2,7 +2,7 @@
 # Run an inference snap in WSL
 
 Inference snaps can be installed in WSL just like on a native Ubuntu installation.
-The hardware detection will not detect GPUs or any other accelerators.
+Because of the way GPUs are exposed on WSL, the hardware detection in inference snaps is not able detect the GPUs.
 A CPU engine will therefore be automatically selected.
 
 If your Windows machine has a GPU that is supported by {spellexception}`WSL's` GPU passthrough mechanism, some inference snaps can also use it.
@@ -36,21 +36,9 @@ clinfo
 
 ## Run inference snap
 
-After installing the relevant inference snap, verify which engine was automatically selected:
-```shell
-<inference-snap> status
-```
+Install a supported inference snap.
 
-You should see a CPU engine.
-
-Use `<inference-snap> list-engines` to find the engine with a description that matches your GPU.
-Switch to that engine and restart the snap.
-
-```shell
-<inference-snap> list-engines
-sudo <inference-snap> use-engine <engine-name>
-sudo snap restart <inference-snap>
-```
+From the list of engines, find the engine with a description that matches your GPU:
 
 You can verify that the engine is running by looking at the snap logs:
 ```shell

--- a/docs/reference/snaps.md
+++ b/docs/reference/snaps.md
@@ -41,6 +41,8 @@ This inference snap is optimized for the following hardware:
 
 {{explore_optimizations}}
 
+{{wsl_support}}
+
 ## Nemotron 3 Nano
 [![nemotron-3-nano snap](https://snapcraft.io/nemotron-3-nano/badge.svg)](https://snapcraft.io/nemotron-3-nano) 
 [![nemotron-3-nano source][gh-badge]](https://github.com/canonical/nemotron-3-nano-snap)

--- a/docs/reuse/substitutions.yaml
+++ b/docs/reuse/substitutions.yaml
@@ -5,3 +5,6 @@ site_link: "[Website link](https://example.com)"
 
 explore_optimizations: |
   Once installed, use `list-engines` and `show-engine` commands to explore the available {ref}`engines <engines>`.
+
+wsl_support: |
+  This snap is supported on Windows Subsystem for Linux (WSL) 2. See {ref}`Run in WSL <run-in-wsl>` for more details.


### PR DESCRIPTION
This PR adds a how-to describing the use of an inference snap, specifically gemma3, in WSL. Gemma3's support for WSL was added in https://github.com/canonical/gemma3-snap/pull/88