### PR TITLE
Documentation for AMD support added to gemma3

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -46,6 +46,8 @@ llamafile
 LLM
 LLMs
 localhost
+microarchitecture
+microarchitectures
 multimodal
 Multipass
 MyST

--- a/docs/reference/engine-manifest.md
+++ b/docs/reference/engine-manifest.md
@@ -81,7 +81,7 @@ field is  mandatory. The remaining fields are architecture specific.
 * `compute-capability` - applicable to NVIDIA (vendor-id `0x10de`) only. A list
 of MAJOR.MINOR version strings prefixed with a comparison operator (==, \<=, \>=, \>, \<[^1]).
 MAJOR and MINOR must both be integers.
-* `microarchitecture` - applicable to AMD (vendor-id `0x1002`). A list of supported AMD GPU {spellexception}`microarchitectures`, e.g., `gfx1030`, `gfx1100`, `gfx1102`.
+* `microarchitecture` - applicable to AMD (vendor-id `0x1002`) only. The supported AMD GPU `microarchitecture`, e.g., `gfx1030`
 
 When bus is set to PCI, this object inherits all {ref}`PCI peripheral <pci-peripherals>` fields.
 

--- a/docs/reference/engine-manifest.md
+++ b/docs/reference/engine-manifest.md
@@ -81,6 +81,7 @@ field is  mandatory. The remaining fields are architecture specific.
 * `compute-capability` - applicable to NVIDIA (vendor-id `0x10de`) only. A list
 of MAJOR.MINOR version strings prefixed with a comparison operator (==, \<=, \>=, \>, \<[^1]).
 MAJOR and MINOR must both be integers.
+* `microarchitecture` - applicable to AMD (vendor-id `0x1002`). A list of supported AMD GPU microarchitectures, e.g., `gfx1030`, `gfx1100`, `gfx1102`.
 
 When bus is set to PCI, this object inherits all {ref}`PCI peripheral <pci-peripherals>` fields.
 

--- a/docs/reference/engine-manifest.md
+++ b/docs/reference/engine-manifest.md
@@ -118,6 +118,9 @@ When bus is set to PCI, this object inherits all {ref}`PCI peripheral <pci-perip
         # device-id:
         vram: 4G
         compute-capability: ["==5.3", ">=6.2"]
+      - type: gpu
+        vendor-id: "0x1002" # Advanced Micro Devices, Inc.
+        microarchitecture: gfx1010
   memory: 4G
   disk-space: 15G
 

--- a/docs/reference/engine-manifest.md
+++ b/docs/reference/engine-manifest.md
@@ -81,7 +81,7 @@ field is  mandatory. The remaining fields are architecture specific.
 * `compute-capability` - applicable to NVIDIA (vendor-id `0x10de`) only. A list
 of MAJOR.MINOR version strings prefixed with a comparison operator (==, \<=, \>=, \>, \<[^1]).
 MAJOR and MINOR must both be integers.
-* `microarchitecture` - applicable to AMD (vendor-id `0x1002`). A list of supported AMD GPU microarchitectures, e.g., `gfx1030`, `gfx1100`, `gfx1102`.
+* `microarchitecture` - applicable to AMD (vendor-id `0x1002`). A list of supported AMD GPU {spellexception}`microarchitectures`, e.g., `gfx1030`, `gfx1100`, `gfx1102`.
 
 When bus is set to PCI, this object inherits all {ref}`PCI peripheral <pci-peripherals>` fields.
 

--- a/docs/reference/snaps.md
+++ b/docs/reference/snaps.md
@@ -38,6 +38,7 @@ This inference snap is optimized for the following hardware:
 | arm64 | Generic CPU | Optimized for {spellexception}`armv8` and {spellexception}`armv9` CPUs |
 | amd64 | NVIDIA GPU | CUDA-enabled GPU acceleration |
 | arm64 | NVIDIA GPU | CUDA-enabled GPU acceleration on arm64 platforms  |
+| amd64 | AMD GPU | ROCm-enabled GPU acceleration on x86 platforms |
 
 {{explore_optimizations}}
 

--- a/docs/reference/snaps.md
+++ b/docs/reference/snaps.md
@@ -38,7 +38,7 @@ This inference snap is optimized for the following hardware:
 | arm64 | Generic CPU | Optimized for {spellexception}`armv8` and {spellexception}`armv9` CPUs |
 | amd64 | NVIDIA GPU | CUDA-enabled GPU acceleration |
 | arm64 | NVIDIA GPU | CUDA-enabled GPU acceleration on arm64 platforms  |
-| amd64 | AMD GPU | ROCm-enabled GPU acceleration on x86 platforms |
+| amd64 | AMD GPU | {spellexception}`ROCm`-enabled GPU acceleration on x86 platforms |
 
 {{explore_optimizations}}
 


### PR DESCRIPTION
Added:

- Gemma3 new engine for AMD gpus
- `microarchitecture` additional property
- example of how to use `microarchitecture` field