### PR TITLE
docs: add qwen3 snap to available snaps list

### DIFF
--- a/docs/reference/snaps.md
+++ b/docs/reference/snaps.md
@@ -117,6 +117,22 @@ The inference snap for Qwen 2.5 VL has been optimized for the following:
 
 {{explore_optimizations}}
 
+## Qwen3
+[![qwen3 snap](https://snapcraft.io/qwen3/badge.svg)](https://snapcraft.io/qwen3)
+[![qwen3 source][gh-badge]](https://github.com/canonical/qwen3-snap)
+
+Qwen3 is a Large Language Model supporting text inputs and outputs, with built-in thinking/reasoning mode.
+
+The inference snap for Qwen3 has been optimized for the following:
+
+| Arch | Optimization | Description |
+|--------------|--------------|-------------|
+| amd64 | Generic CPU | llama.cpp CPU inference |
+| amd64 | NVIDIA GPU | CUDA-enabled GPU acceleration |
+| amd64 | AMD GPU | {spellexception}`ROCm`-enabled GPU acceleration |
+
+{{explore_optimizations}}
+
 <!--
 ## Deprecated snaps
 


### PR DESCRIPTION
Adds the `qwen3` inference snap entry to `docs/reference/snaps.md`, inserted after Qwen VL in alphabetical order.\n\nSnap repo: https://github.com/canonical/qwen3-snap\nModel: unsloth/Qwen3-0.6B-GGUF (Q4_K_M, ~378 MB)\nEngines: cpu, nvidia-gpu, amd-gpu