### PR TITLE
docs: add Qwen3 to available snaps list

### DIFF
--- a/docs/reference/snaps.md
+++ b/docs/reference/snaps.md
@@ -123,6 +123,25 @@ The inference snap for Qwen 2.5 VL has been optimized for the following:
 
 {{explore_optimizations}}
 
+## Qwen3
+
+[![qwen3 snap](https://snapcraft.io/qwen3/badge.svg)](https://snapcraft.io/qwen3)
+[![qwen3 source][gh-badge]](https://github.com/canonical/qwen3-snap)
+
+Qwen3 is a Large Language Model designed for both reasoning and non-reasoning tasks.
+The input and output are text-based.
+
+The inference snap for Qwen3 has been optimized for the following:
+
+| Arch | Optimization | Description |
+|--------------|--------------|-------------|
+| amd64 | Generic CPU | Optimized for several x86 CPU variants |
+| arm64 | Generic CPU | Optimized for {spellexception}`armv8` and {spellexception}`armv9` CPUs |
+| amd64 | NVIDIA GPU | CUDA-enabled GPU acceleration on x86 platforms |
+| arm64 | NVIDIA GPU | CUDA-enabled GPU acceleration on arm64 platforms  |
+
+{{explore_optimizations}}
+
 <!--
 ## Deprecated snaps
 


### PR DESCRIPTION
Adds the new [qwen3](https://github.com/canonical/qwen3-snap) inference snap to the available snaps reference page.

Qwen3 is a text-in/text-out LLM (reasoning + non-reasoning) packaged with CPU and NVIDIA GPU (CUDA) optimizations on amd64 and arm64.

The entry matches the existing format and is placed alphabetically after the Qwen VL section.

Related: companion snap PR canonical/qwen3-snap#5