### PR TITLE
Split IDE integration docs

### DIFF
--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -3,6 +3,7 @@
 .venv/
 
 # Sphinx
+.sphinx/
 _dev/warnings.txt
 _dev/.wordlist.dic
 _dev/.doctrees/

--- a/docs/how-to/integration/configure-jetbrains-ides.md
+++ b/docs/how-to/integration/configure-jetbrains-ides.md
@@ -22,6 +22,7 @@ If you find a config.json file instead of the YAML file, refer to this [YAML mig
 ```
 
 You can also open it from the plugin as follows:
+
 1. In the right [tool window bar][tool-window-bar], select the Continue logo
 2. Click on the **Select model** drop down menu
 3. In the new window, click the configuration icon (⚙️) to open `config.yaml`

--- a/docs/how-to/integration/configure-jetbrains-ides.md
+++ b/docs/how-to/integration/configure-jetbrains-ides.md
@@ -14,7 +14,7 @@ It assumes that the snap has already been installed and configured.
 
 Open the configuration file `config.yaml`.
 The [config.yaml reference page][continue-ref] describes the possible locations of this file.
-It’s usually located at `~/.continue/config.yaml`.
+It's usually located at `~/.continue/config.yaml`.
 
 
 ```{note}

--- a/docs/how-to/integration/configure-jetbrains-ides.md
+++ b/docs/how-to/integration/configure-jetbrains-ides.md
@@ -1,0 +1,60 @@
+(configure-jetbrains-ides)=
+
+# Use an inference snap from your favorite JetBrains IDE
+
+Inference snaps provide an API that can be integrated with other software.
+This guide explains how to integrate an inference snap with your favorite JetBrains IDE.
+It assumes that the snap has already been installed and configured.
+
+## Install Continue
+
+[Continue][continue-docs] enables integration of locally running models with the IDE. Install the Continue plugin by searching for **Continue** in the plugins menu on the welcome screen of the IDE, or by going to **File** > **Settings** > **Plugins** and searching for **Continue**.
+
+## Configure Continue
+
+Open the configuration file `config.yaml`.
+The [config.yaml reference page][continue-ref] describes the possible locations of this file.
+It’s usually located at `~/.continue/config.yaml`.
+
+
+```{note}
+If you find a config.json file instead of the YAML file, refer to this [YAML migration guide](https://docs.continue.dev/reference/yaml-migration). 
+```
+
+You can also open it from the plugin as follows:
+1. In the right [tool window bar][tool-window-bar], select the Continue logo
+2. Click on the **Select model** drop down menu
+3. In the new window, click the configuration icon (⚙️) to open `config.yaml`
+
+
+Find the `models` list in the YAML file and add:
+
+```yaml
+  - name: Qwen-VL
+    provider: openai
+    apiBase: http://localhost:8326/v3
+    model: Qwen2.5-VL-3B-Instruct-ov-int4
+    roles:
+      - chat
+      - edit
+```
+
+The values above are examples based on the `qwen-vl` inference snap.
+Update `name`, `model`, and `apiBase` to match your specific snap and its configuration.
+To identify the correct `apiBase` and `model` name, check out this guide on {ref}`using the snap via its OpenAI API<use-openai-api>`.
+
+For additional configuration options, visit the [Continue reference page][continue-ref].
+
+## Use the inference snap with Continue
+
+Once the model is configured, it can be selected from the Select Model drop down at the bottom of the Continue chat box.
+Any requests in the chat box will be sent to the selected model.
+
+```{tip}
+Explore the [Continue documentation][continue-docs] to learn how to use it for coding, chat and more.
+```
+
+<!-- links -->
+[continue-ref]: https://docs.continue.dev/reference
+[continue-docs]: https://docs.continue.dev/
+[tool-window-bar]: https://www.jetbrains.com/help/idea/tool-windows.html#bars_and_buttons

--- a/docs/how-to/integration/configure-vs-code.md
+++ b/docs/how-to/integration/configure-vs-code.md
@@ -14,7 +14,7 @@ It assumes that the snap has already been installed and configured.
 
 Open the configuration file `config.yaml`.
 The [config.yaml reference page][continue-ref] describes the possible locations of this file.
-It’s usually located at `~/.continue/config.yaml`.
+It's usually located at `~/.continue/config.yaml`.
 
 
 ```{note}

--- a/docs/how-to/integration/configure-vs-code.md
+++ b/docs/how-to/integration/configure-vs-code.md
@@ -1,26 +1,14 @@
-(use-in-ide)=
+(configure-vs-code)=
 
-# Use an inference snap from your favorite IDE
+# Use inference snaps in Visual Studio Code
 
 Inference snaps provide an API that can be integrated with other software.
-This guide explains how to integrate an inference snap with your favorite IDE.
+This guide explains how to integrate an inference snap with Visual Studio Code.
 It assumes that the snap has already been installed and configured.
 
 ## Install Continue
 
-[Continue][continue-docs] enables integration of locally running models with the IDE.
-
-````{tabs}
-
-```{group-tab} VS Code
-Install the Continue extension by searching for **Continue - open-source AI code assistant** in the VS Code [Extensions view][vs-code-extensions].
-```
-
-```{group-tab} JetBrains IDEs
-Install the Continue plugin by searching for **Continue** in the plugins menu on the welcome screen of the IDE, or by going to **File** > **Settings** > **Plugins** and searching for **Continue**.
-```
-
-````
+[Continue][continue-docs] enables integration of locally running models with the IDE. Install the Continue extension by searching for **Continue - open-source AI code assistant** in the VS Code [Extensions view][vs-code-extensions].
 
 ## Configure Continue
 
@@ -33,24 +21,11 @@ It’s usually located at `~/.continue/config.yaml`.
 If you find a config.json file instead of the YAML file, refer to this [YAML migration guide](https://docs.continue.dev/reference/yaml-migration). 
 ```
 
-````{tabs}
-
-```{group-tab} VS Code
 You can also open it from the extension as follows:
 
 1. In the [Activity Bar][activity-bar], select the Continue logo
 2. Click on the **Select model** drop down menu
 3. In the new window, click the configuration icon (⚙️) to open `config.yaml`
-```
-
-```{group-tab} JetBrains IDEs
-You can also open it from the plugin as follows:
-1. In the right [tool window bar][tool-window-bar], select the Continue logo
-2. Click on the **Select model** drop down menu
-3. In the new window, click the configuration icon (⚙️) to open `config.yaml`
-```
-````
-
 
 Find the `models` list in the YAML file and add:
 
@@ -84,4 +59,3 @@ Explore the [Continue documentation][continue-docs] to learn how to use it for c
 [continue-docs]: https://docs.continue.dev/
 [vs-code-extensions]: https://code.visualstudio.com/docs/getstarted/extensions#_install-a-vs-code-extension
 [activity-bar]: https://code.visualstudio.com/docs/getstarted/userinterface#_basic-layout
-[tool-window-bar]: https://www.jetbrains.com/help/idea/tool-windows.html#bars_and_buttons

--- a/docs/how-to/integration/index.md
+++ b/docs/how-to/integration/index.md
@@ -1,3 +1,5 @@
+(integration)=
+
 # Integrate with inference snaps
 
 Inference snaps provide standard API endpoints that can be used for integration with most existing clients.
@@ -11,9 +13,10 @@ OpenCode <configure-opencode>
 OpenShell <configure-openshell>
 ```
 
-Use the snap with your IDE:
+Use the snap with your IDEs:
 
 ```{toctree}
 :maxdepth: 1
-IDEs <use-in-ide>
+Visual Studio Code <configure-vs-code>
+JetBrains IDEs <configure-jetbrains-ides>
 ```

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -6,3 +6,4 @@
 # The old path must be a file that doesn"t exist in the source. The current path must be
 # a file that does exist in the source.
 
+./how-to/integration/use-in-ide/ ./how-to/integration/

--- a/docs/redirects.txt
+++ b/docs/redirects.txt
@@ -3,7 +3,7 @@
 #     "<old path>" "<current path>"
 #
 # Paths must be represented as source files relative to the root of the docs directory.
-# The old path must be a file that doesn"t exist in the source. The current path must be
+# The old path must be a file that doesn't exist in the source. The current path must be
 # a file that does exist in the source.
 
-./how-to/integration/use-in-ide/ ./how-to/integration/
+how-to/integration/use-in-ide how-to/integration

--- a/docs/tutorial/qwen-vl-tutorial.md
+++ b/docs/tutorial/qwen-vl-tutorial.md
@@ -10,7 +10,7 @@ This model is also referred to as a Vision Language Model (VLM) because it can i
 
 To complete this tutorial you will need:
 
-- A computer running an operating system that supports snaps, e.g., Ubuntu 24.04. Older Ubuntu versions aren't supported.
+- A computer running an operating system that supports snaps, e.g., Ubuntu 24.04 LTS. Older Ubuntu versions aren't supported.
 - Hardware drivers. These may be pre-installed in your OS, but some devices require {ref}`additional drivers <install-drivers>`.
 - A Docker installation
 
@@ -116,4 +116,4 @@ However, the model spotted the triangular buoy and responded according to that i
 
 To become more familiar with inference snaps:
 - Learn how to {ref}`switch to a different engine <switch-between-engines>` after installation
-- Configure an inference snap to {ref}`work with your IDE <use-in-ide>`
+- Configure an inference snap to {ref}`work with your clients <integration>`


### PR DESCRIPTION
Splits the how-to guides for IDE integration in two different pages.

Resolves #289 