### PR TITLE
docs: Add Qwen3.6 to the available snaps reference

### DIFF
--- a/docs/reference/snaps.md
+++ b/docs/reference/snaps.md
@@ -125,11 +125,11 @@ The inference snap for Qwen 2.5 VL has been optimized for the following:
 
 ## Qwen3.6
 
-[![qwen36 snap](https://snapcraft.io/qwen36/badge.svg)](https://snapcraft.io/qwen36)
-[![qwen36 source][gh-badge]](https://github.com/canonical/qwen3.6-snap)
+[![qwen3-6 snap](https://snapcraft.io/qwen3-6/badge.svg)](https://snapcraft.io/qwen3-6)
+[![qwen3-6 source][gh-badge]](https://github.com/canonical/qwen3.6-snap)
 
 Qwen3.6 is a Mixture-of-Experts Large Language Model designed for reasoning and chat completions.
-Input and output is text-based.
+It supports text and image inputs, with text-based outputs.
 
 This inference snap is optimized for the following hardware:
 

--- a/docs/reference/snaps.md
+++ b/docs/reference/snaps.md
@@ -123,6 +123,26 @@ The inference snap for Qwen 2.5 VL has been optimized for the following:
 
 {{explore_optimizations}}
 
+## Qwen3.6
+
+[![qwen36 snap](https://snapcraft.io/qwen36/badge.svg)](https://snapcraft.io/qwen36)
+[![qwen36 source][gh-badge]](https://github.com/canonical/qwen3.6-snap)
+
+Qwen3.6 is a Mixture-of-Experts Large Language Model designed for reasoning and chat completions.
+Input and output is text-based.
+
+This inference snap is optimized for the following hardware:
+
+| Arch | Optimization | Description |
+|--------------|--------------|-------------|
+| amd64 | Generic CPU | Optimized for several x86 CPU variants |
+| arm64 | Generic CPU | Optimized for {spellexception}`armv8` and {spellexception}`armv9` CPUs |
+| amd64 | NVIDIA GPU | CUDA-enabled GPU acceleration |
+| arm64 | NVIDIA GPU | CUDA-enabled GPU acceleration on arm64 platforms  |
+| amd64 | AMD GPU | {spellexception}`ROCm`-enabled GPU acceleration on x86 platforms |
+
+{{explore_optimizations}}
+
 <!--
 ## Deprecated snaps
 


### PR DESCRIPTION
Adds an entry for the **Qwen3.6** inference snap to the available snaps reference (`docs/reference/snaps.md`), matching the existing format and ordering (placed after Qwen VL).

The entry covers the `qwen3-6` snap ([canonical/qwen3.6-snap](https://github.com/canonical/qwen3.6-snap)) and lists its supported optimizations:

| Arch | Optimization | Engine |
|------|--------------|--------|
| amd64 / arm64 | Generic CPU | llama.cpp |
| amd64 / arm64 | NVIDIA GPU | llama.cpp + CUDA |
| amd64 | AMD GPU | llama.cpp + ROCm |

The model is multimodal: text and image inputs, with text-based outputs.

Related snap PR: canonical/qwen3.6-snap#1
